### PR TITLE
MDBF-1052 - Add lazy initialization in MariaDBStore

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,8 @@
 version: "3"
 
 services:
-  postgres:
+  mariadb:
+    container_name: mariadb-server
     image: mariadb:11.7
     environment:
       MARIADB_USER: langchain

--- a/langchain_mariadb/vectorstores.py
+++ b/langchain_mariadb/vectorstores.py
@@ -392,9 +392,9 @@ class MariaDBStore(VectorStore):
         if not self.lazy_init:
             if self._embedding_length is None:
                 self._embedding_length = 1536
-            self.__post_init__()
+            self._init_vectorstore()
 
-    def __post_init__(
+    def _init_vectorstore(
         self,
     ) -> None:
         """Initialize the store."""
@@ -796,7 +796,7 @@ class MariaDBStore(VectorStore):
         embeddings = self.embedding_function.embed_documents(texts_)
         if self.lazy_init and embeddings:
             self._embedding_length = len(embeddings[0])
-            self.__post_init__()
+            self._init_vectorstore()
         return self.add_embeddings(
             texts=texts_,
             embeddings=list(embeddings),
@@ -1305,7 +1305,7 @@ class MariaDBStore(VectorStore):
 
         if self.lazy_init and not self._embedding_length:
             self._embedding_length = len(embedding)
-            self.__post_init__()
+            self._init_vectorstore()
 
         return self.__inner_query_collection(embedding=embedding, k=k, query_=query)
 

--- a/langchain_mariadb/vectorstores.py
+++ b/langchain_mariadb/vectorstores.py
@@ -19,14 +19,12 @@ from typing import (
     cast,
 )
 
-import mariadb
 import numpy as np
 from langchain_core.documents import Document
 from langchain_core.embeddings import Embeddings
 from langchain_core.runnables.config import run_in_executor
 from langchain_core.vectorstores import VectorStore
 from langchain_core.vectorstores.utils import maximal_marginal_relevance
-from mariadb.constants import ERR as mariadb_err
 from sqlalchemy import create_engine
 from sqlalchemy.engine import Engine
 
@@ -638,9 +636,11 @@ class MariaDBStore(VectorStore):
                 data,
             )
             con.commit()
-        except mariadb.Error as e:
-            if e.errno == mariadb_err.ER_NO_SUCH_TABLE:
-                return   
+        except Exception as e:
+            if hasattr(e, "errno") and e.errno == 1146: # NO SUCH TABLE
+                return
+            else:
+                raise e
         finally:
             cursor.close()
             con.close()

--- a/tests/unit_tests/test_vectorstore.py
+++ b/tests/unit_tests/test_vectorstore.py
@@ -5,6 +5,7 @@ import json
 from contextlib import contextmanager
 from typing import Any, Dict, Generator, List, Sequence
 
+import mariadb
 import pytest
 import sqlalchemy
 
@@ -46,6 +47,14 @@ def pool() -> Generator[Engine, None, None]:
 
 ADA_TOKEN_COUNT = 1536
 
+def _count_no_of_tables(engine: Engine) -> int:
+    """Count the number of tables in the database."""
+    connection = engine.raw_connection()
+    cursor = connection.cursor()
+    cursor.execute("SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = 'langchain' and table_name like 'langchain_%'")
+    count = int(cursor.fetchone()[0])
+    cursor.close()
+    return count
 
 def _compare_documents(left: Sequence[Document], right: Sequence[Document]) -> None:
     """Compare lists of documents, irrespective of IDs."""
@@ -1104,3 +1113,128 @@ def test_mariadb_store_with_with_metadata_filters_5(
     with get_vectorstore() as store:
         docs = store.similarity_search("meow", k=5, filter=test_filter)
         assert [doc.metadata["id"] for doc in docs] == expected_ids, test_filter
+
+def test_mariadb_lazy_store_with_metadatas() -> None:
+    """Test end to end construction and search using lazy initialisation."""
+    texts = ["foo", "bar", "baz"]
+    metadatas = [{"page": str(i)} for i in range(len(texts))]
+    with pool() as tmppool:
+        store = MariaDBStore(
+            embeddings=FakeEmbeddingsWithAdaDimension(),
+            collection_name="test_collection",
+            datasource=tmppool,
+            config=MariaDBStoreSettings(pre_delete_collection=True, lazy_init=True),
+        )
+        store.add_texts(
+            texts=texts,
+            metadatas=metadatas,
+        )
+        output = store.similarity_search("foo", k=1)
+        _compare_documents(
+            output, [Document(page_content="foo", metadata={"page": "0"})]
+        )
+
+def test_mariadb_lazy_check_tables_init_after_search() -> None:
+    """Test tables exist after search with lazy initialisation."""
+    texts = ["foo", "bar", "baz"]
+    metadatas = [{"page": str(i)} for i in range(len(texts))]
+    with pool() as tmppool:
+        store = MariaDBStore(
+            embeddings=FakeEmbeddingsWithAdaDimension(),
+            collection_name="test_collection",
+            datasource=tmppool,
+            config=MariaDBStoreSettings(pre_delete_collection=True, lazy_init=True),
+        )
+        assert _count_no_of_tables(tmppool) == 0
+        store.similarity_search("foo", k=1)
+        assert _count_no_of_tables(tmppool) == 2
+
+@pytest.mark.asyncio
+async def test_mariadb_lazy_check_tables_init_after_async_search() -> None:
+    """Test tables exist after async search with lazy initialisation."""
+    texts = ["foo", "bar", "baz"]
+    metadatas = [{"page": str(i)} for i in range(len(texts))]
+    with pool() as tmppool:
+        store = MariaDBStore(
+            embeddings=FakeEmbeddingsWithAdaDimension(),
+            collection_name="test_collection",
+            datasource=tmppool,
+            config=MariaDBStoreSettings(pre_delete_collection=True, lazy_init=True),
+        )
+        assert _count_no_of_tables(tmppool) == 0
+        await store.asimilarity_search("foo", k=1)
+        assert _count_no_of_tables(tmppool) == 2
+
+def test_mariadb_lazy_tables_exist_after_addtexts() -> None:
+    """Test adding texts with lazy initialisation."""
+    texts = ["foo", "bar", "baz"]
+    metadatas = [{"page": str(i)} for i in range(len(texts))]
+    with pool() as tmppool:
+        store = MariaDBStore(
+            embeddings=FakeEmbeddingsWithAdaDimension(),
+            collection_name="test_collection",
+            datasource=tmppool,
+            config=MariaDBStoreSettings(pre_delete_collection=True, lazy_init=True),
+        )
+        assert _count_no_of_tables(tmppool) == 0
+        store.add_texts(
+            texts=texts,
+            metadatas=metadatas,
+        )
+        assert _count_no_of_tables(tmppool) == 2
+
+def test_mariadbstore_lazy_from_texts() -> None:
+    """Test end to end construction and search with lazy initialisation."""
+    texts = ["foo", "bar", "baz"]
+    with pool() as tmppool:
+        docsearch = MariaDBStore.from_texts(
+            texts=texts,
+            collection_name="test_collection",
+            embedding=FakeEmbeddingsWithAdaDimension(),
+            embedding_length=ADA_TOKEN_COUNT,
+            datasource=tmppool,
+            engine_args={"pool_size": 2},
+            config=MariaDBStoreSettings(pre_delete_collection=True, lazy_init=True),
+        )
+        output = docsearch.similarity_search("foo", k=1)
+        _compare_documents(output, [Document(page_content="foo")])
+
+        output = docsearch.search("foo", "similarity", k=1)
+        _compare_documents(output, [Document(page_content="foo")])
+
+def test_mariadb_store_lazy_delete_docs() -> None:
+    """Test delete docs with lazy initialisation"""
+    texts = ["foo", "bar", "baz"]
+    metadatas = [{"page": str(i)} for i in range(len(texts))]
+    with pool() as tmppool:
+        store = MariaDBStore(
+            embeddings=FakeEmbeddingsWithAdaDimension(),
+            collection_name="test_collection_filter",
+            datasource=tmppool,
+            config=MariaDBStoreSettings(pre_delete_collection=True, lazy_init=True),
+        )
+
+        assert _count_no_of_tables(tmppool) == 0
+        store.delete(
+            [
+                "00000000-0000-4000-0000-000000000000",
+                "10000000-0000-4000-0000-000000000000",
+            ]
+        )
+        assert _count_no_of_tables(tmppool) == 0
+
+def test_mariadb_store_lazy_delete_collection() -> None:
+    """Test delete collection with lazy initialisation."""
+    texts = ["foo", "bar", "baz"]
+    metadatas = [{"page": str(i)} for i in range(len(texts))]
+    with pool() as tmppool:
+
+        store = MariaDBStore(
+            embeddings=FakeEmbeddingsWithAdaDimension(),
+            collection_name="test_collection",
+            datasource=tmppool,
+            config=MariaDBStoreSettings(pre_delete_collection=True, lazy_init=True),
+        )
+        assert _count_no_of_tables(tmppool) == 0
+        store.delete_collection()
+        assert _count_no_of_tables(tmppool) == 0


### PR DESCRIPTION
The primary motivation for this patch is that, in a client-server application (e.g., RAG), the developer might not or isn't required to know the `embedding_length` in advance.
Without lazy init and no prior knowledge of the `embedding_length`, the developer would be stuck with the default of `1536`, which might differ from what the model actual value is.

Of course, `from_texts()` will determine the dimension at runtime but we need to consider that
in some cases one would like to get an instance of `MariaDBStore` first and then perform any other operations later.

Thus, we now support lazy initialization of the store, which will establish the embedding dimension
and create the tables on either the first search or the first insert, whichever comes first.